### PR TITLE
package: rm unused npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "gulp": "^3.9.1",
     "is-online": "^5.1.2",
-    "npm-run-all": "^3.1.1",
     "precss": "^1.4.0",
     "stylelint": "^7.5.0"
   }


### PR DESCRIPTION
Removed unused dependency: `npm-run-all`.